### PR TITLE
BUG: Change dir permissions fix

### DIFF
--- a/src/Extensions/ComposerLoaderExtension.php
+++ b/src/Extensions/ComposerLoaderExtension.php
@@ -120,10 +120,17 @@ class ComposerLoaderExtension extends Extension
         }
 
         $originalDir = getcwd();
-        chdir(BASE_PATH);
+
+        if ($originalDir !== BASE_PATH) {
+            chdir(BASE_PATH);
+        }
+
         /** @var Composer $composer */
         $composer = Factory::create(new NullIO());
         $this->setComposer($composer);
-        chdir($originalDir);
+
+        if ($originalDir !== BASE_PATH) {
+            chdir($originalDir);
+        }
     }
 }


### PR DESCRIPTION
We  noticed that in some cases we get the following error:

```
E_WARNING: chdir(): Permission denied (errno 13) ComposerLoaderExtension.php:127
```

This change avoids switching current working directory unless it's really needed. This helps avoid potential permission denied errors without changing the functionality.