### PR TITLE
DEP Allow installation of composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3 || ^8.0",
-        "composer/composer": "^1",
+        "composer/composer": "^1 || ^2",
         "silverstripe/framework": "^4.10",
         "bringyourownideas/silverstripe-maintenance": "^2"
     },


### PR DESCRIPTION
This PR allows the installation of both composer v1 and v2. The API between v1 and v2 hasn't change much so supporting both of them simultaneously shouldn't be too much of a problem (he said confidently)

# Parent issue
- [x] https://github.com/silverstripe/silverstripe-framework/issues/10146