### PR TITLE
DEP Require composer ^1.10, remove branch-alias

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.9
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.12

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3 || ^8.0",
-        "composer/composer": "^1",
+        "composer/composer": "^1.10",
         "silverstripe/framework": "^4.10",
         "bringyourownideas/silverstripe-maintenance": "^2"
     },
@@ -45,11 +45,6 @@
         "psr-4": {
             "BringYourOwnIdeas\\UpdateChecker\\": "src/",
             "BringYourOwnIdeas\\UpdateChecker\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
         }
     },
     "replace": {


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/512

Issue trying to be solved here is that recipe-reporting-tools - https://app.travis-ci.com/github/silverstripe/recipe-reporting-tools/jobs/551879128 - is installing composer/composer 1.0.0-alpha10 instead of a more recent 1.10 version of composer/composer

Release 2.1.1 when merged