### PR TITLE
FIX Don't rely on inaccessible packages when fetching update info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ will need to have the necessary permissions to access the private VCS repositori
 update information about necessary updates to the module.
 
 If the process looking for available updates fails (for example, due to an authentication failure against a private
-repository) the process will fail gracefully and allow the rest of the report generation to continue.
+repository) the process will fail gracefully and allow the rest of the report generation to continue. However, this
+can result in incomplete information being fetched about non-private repositories due to the way composer checks for
+conflicts between packages. For this reason, if you cannot supply authentication details for private repositories,
+you should mark those repositories as inaccessible as per the documentation in the [SilverStripe Maintenance module](https://github.com/bringyourownideas/silverstripe-maintenance#private-repositories).
 
 Users on the [Common Web Platform](https://cwp.govt.nz) will currently not be able to retrieve information about
 updates to private repositories.

--- a/src/DriverReflection.php
+++ b/src/DriverReflection.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace BringYourOwnIdeas\UpdateChecker;
+
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Repository\VcsRepository;
+use ReflectionObject;
+use RuntimeException;
+
+class DriverReflection
+{
+    public static function getDriverWithoutException(VcsRepository $repo, IOInterface $io, Config $config)
+    {
+        $reflectedRepo = new ReflectionObject($repo);
+        $drivers = static::getRepoField($repo, $reflectedRepo, 'drivers');
+
+        if (isset($drivers[static::getRepoField($repo, $reflectedRepo, 'type')])) {
+            $class = $drivers[static::getRepoField($repo, $reflectedRepo, 'type')];
+            $driver = new $class($repo->getRepoConfig(), $io, $config);
+            try {
+                $driver->initialize();
+            } catch (RuntimeException $e) {
+                // no-op - this is probably caused due to insufficient permissions when trying to create /var/www/.ssh
+                // but since we're just getting the driver as a shortcut to getting the repository name, we can ignore this for now.
+            }
+            return $driver;
+        }
+
+        foreach ($drivers as $driver) {
+            if ($driver::supports($io, $config, static::getRepoField($repo, $reflectedRepo, 'url'))) {
+                $driver = new $driver($repo->getRepoConfig(), $io, $config);
+                try {
+                    $driver->initialize();
+                } catch (RuntimeException $e) {
+                    // no-op - this is probably caused due to insufficient permissions when trying to create /var/www/.ssh
+                    // but since we're just getting the driver as a shortcut to getting the repository name, we can ignore this for now.
+                }
+                return $driver;
+            }
+        }
+
+        foreach ($drivers as $driver) {
+            if ($driver::supports($io, $config, static::getRepoField($repo, $reflectedRepo, 'url'), true)) {
+                $driver = new $driver($repo->getRepoConfig(), $io, $config);
+                try {
+                    $driver->initialize();
+                } catch (RuntimeException $e) {
+                    // no-op - this is probably caused due to insufficient permissions when trying to create /var/www/.ssh
+                    // but since we're just getting the driver as a shortcut to getting the repository name, we can ignore this for now.
+                }
+                return $driver;
+            }
+        }
+    }
+
+    public static function getSshUrl($driver)
+    {
+        $reflectedDriver = new ReflectionObject($driver);
+        if ($reflectedDriver->hasMethod('generateSshUrl')) {
+            $reflectedMethod = $reflectedDriver->getMethod('generateSshUrl');
+            $reflectedMethod->setAccessible(true);
+            return $reflectedMethod->invoke($driver);
+        }
+        return null;
+    }
+
+    protected static function getRepoField(VcsRepository $repo, ReflectionObject $reflectedRepo, string $field)
+    {
+        $reflectedUrl = $reflectedRepo->getProperty($field);
+        $reflectedUrl->setAccessible(true);
+        return $reflectedUrl->getValue($repo);
+    }
+}


### PR DESCRIPTION
Fixes #49 

Composer wants to use information about all dependencies when reporting the most up-to-date version that meets the project's stability/version constraints and doesn't conflict with any other dependencies.
If a dependency is inaccessible (e.g. private repositories or IP-restricted hosting) composer will fail to declare a version candidate, which results in missing information even for some accessible packages.

By ommitting inaccessible repositories, we do at least get _some_ version information, even if there is a change of compatibility issues.

All #49 is asking for is a way to suppress the below logging for specific packages. It _looks like_ the only thing that we really need to do is check before logging if this is one of the repositories to suppress for - but the packages being checked for updates are _not necessarily_ the packages that can't be fetched.
https://github.com/bringyourownideas/silverstripe-composer-update-checker/blob/ba8bae91c031a285eea046e09a9167d90d52b1ba/src/Extensions/CheckComposerUpdatesExtension.php#L62-L67

Ultimately what is happening is this:
- Composer gets a list of packages from the project's `composer.json` file.
- Update checker, to find the latest version that can be used, asks for the "best candidate" version for each package.
- Composer checks against _all dependencies_ which checking for the "best candidate" for any conflicts.
- To check _all dependencies_ composer attempts to fetch repository information for each dependency
- When composer fails to fetch repository information for a dependency, it throws an exception.

This means that the package it's trying to get update information for (which is not necessarily the same package that it can't fetch information for) doesn't get the update information stored against it in the report. This PR allows composer to use all the information it _can_ access to give a version candidate. There is a chance of conflicts, but this is better than having no update information at all, IMO.