### PR TITLE
FIX Allow getting update information about all package types.

### DIFF
--- a/src/Extensions/CheckComposerUpdatesExtension.php
+++ b/src/Extensions/CheckComposerUpdatesExtension.php
@@ -37,7 +37,7 @@ class CheckComposerUpdatesExtension extends Extension
     public function updatePackageInfo(array &$installedPackageList)
     {
         // Fetch types of packages that are "allowed" - ie. dependencies that we actually care about
-        $allowedTypes = (array) Config::inst()->get(UpdatePackageInfoTask::class, 'allowed_types');
+        $allowedTypes = Config::inst()->get(UpdatePackageInfoTask::class, 'allowed_types');
         $composerPackagesAndConstraints = $this->owner->getComposerLoader()->getPackages($allowedTypes);
 
         // Loop list of packages given by owner task


### PR DESCRIPTION
If `allowed_types` is null, this allows _all_ package types. There is even a check in `ComposerLoaderExtension::getPackages` (which is the only place this variable is used) to check if the package is an array, and skip the package type check if not.