### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "composer/composer": "^1.10",
         "silverstripe/framework": "^4.10",
         "bringyourownideas/silverstripe-maintenance": "^2"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
