### PR TITLE
NEW Use composer 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.14
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1

--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ the command line to install or update PHP packages.
 ### Requirements
 
 * bringyourownideas/silverstripe-maintenance ^2
-* composer/composer ^1
+* composer/composer ^2
 * silverstripe/framework ^4
 
 #### Compatibility
 
 The 1.x release line of this module is compatible with SilverStripe ^3.2, and the 2.x release line is compatible with
 SilverStripe ^4.0.
+
+The 2.x release line of the module is compatible with composer v1, and this 3.x release line is
+compatible with composer v2
 
 ### Installation
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "composer/composer": "^1.10",
+        "composer/composer": "^2",
         "silverstripe/framework": "^4.10",
         "bringyourownideas/silverstripe-maintenance": "^2"
     },

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -4,11 +4,11 @@ namespace BringYourOwnIdeas\UpdateChecker;
 
 use BringYourOwnIdeas\Maintenance\Util\ComposerLoader;
 use Composer\Composer;
-use Composer\DependencyResolver\Pool;
 use Composer\Package\BasePackage;
 use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\CompositeRepository;
+use Composer\Repository\RepositorySet;
 use SilverStripe\Core\Injector\Injector;
 
 /**
@@ -71,15 +71,14 @@ class UpdateChecker
     {
         if (!$this->versionSelector) {
             // Instantiate a new repository pool, providing the stability flags from the project
-            $pool = new Pool(
+            $respositorySet = new RepositorySet(
                 $composer->getPackage()->getMinimumStability(),
                 $composer->getPackage()->getStabilityFlags()
             );
-            $pool->addRepository(new CompositeRepository($composer->getRepositoryManager()->getRepositories()));
-
-            $this->versionSelector = new VersionSelector($pool);
+            $repo = new CompositeRepository($composer->getRepositoryManager()->getRepositories());
+            $respositorySet->addRepository($repo);
+            $this->versionSelector = new VersionSelector($respositorySet);
         }
-
         return $this->versionSelector;
     }
 
@@ -117,7 +116,7 @@ class UpdateChecker
         }
 
         $targetVersion = null;
-        if (0 === strpos($installedVersion, 'dev-')) {
+        if (0 === strpos($installedVersion ?? '', 'dev-')) {
             $targetVersion = $installedVersion;
         }
 
@@ -126,6 +125,6 @@ class UpdateChecker
             $targetVersion = $constraint;
         }
 
-        return $versionSelector->findBestCandidate($name, $targetVersion, null, $bestStability);
+        return $versionSelector->findBestCandidate($name, $targetVersion, $bestStability);
     }
 }

--- a/tests/Stubs/ComposerLoaderExtensionStub.php
+++ b/tests/Stubs/ComposerLoaderExtensionStub.php
@@ -4,8 +4,9 @@ namespace BringYourOwnIdeas\UpdateChecker\Tests\Stubs;
 
 use BringYourOwnIdeas\UpdateChecker\Extensions\ComposerLoaderExtension;
 use Composer\Package\Package;
-use Composer\Repository\ArrayRepository;
-use Composer\Repository\BaseRepository;
+use Composer\Repository\InstalledRepository;
+use Composer\Repository\InstalledArrayRepository;
+use Composer\Repository\RepositoryInterface;
 use SilverStripe\Dev\TestOnly;
 
 /**
@@ -13,7 +14,7 @@ use SilverStripe\Dev\TestOnly;
  */
 class ComposerLoaderExtensionStub extends ComposerLoaderExtension implements TestOnly
 {
-    protected function getRepository()
+    protected function getRepository(): RepositoryInterface
     {
         $vendorModule = new Package('silverstripe/framework', '4.1.1.0', '4.1.1');
         $vendorModule->setType('silverstripe-vendormodule');
@@ -24,10 +25,12 @@ class ComposerLoaderExtensionStub extends ComposerLoaderExtension implements Tes
         $generalPackage = new Package('something/unrelated', '1.2.3.4', '1.2.3');
         $generalPackage->setType('package');
 
-        return new ArrayRepository([$vendorModule, $silverstripeModule, $generalPackage]);
+        return new InstalledRepository([
+            new InstalledArrayRepository([$vendorModule, $silverstripeModule, $generalPackage])
+        ]);
     }
 
-    protected function getInstalledConstraint(BaseRepository $repository, $packageName)
+    protected function getInstalledConstraint(InstalledRepository $repository, string $packageName): string
     {
         switch ($packageName) {
             case 'silverstripe/framework':

--- a/tests/UpdateCheckerTest.php
+++ b/tests/UpdateCheckerTest.php
@@ -55,7 +55,6 @@ class UpdateCheckerTest extends SapphireTest
             ->method('findLatestPackage')
             ->will($this->returnValue($mockPackage));
 
-
         $result = $this->updateChecker->checkForUpdates($mockPackage, '~1.2.0');
         $this->assertArrayNotHasKey('AvailableVersion', $result, 'No available update is recorded');
         $this->assertArrayNotHasKey('AvailableHash', $result, 'No available update is recorded');


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10250

Switch from composer 1 to composer 2, also add the `??` operator to a few native function calls to ensure null values aren't passed in for PHP 8.1 compatibility

Create 3 + 3.0 branches and tag 3.0.0 when merged

Required for https://github.com/silverstripe/recipe-reporting-tools/pull/26