### PR TITLE
MNT Remove fix deprecated test

### DIFF
--- a/tests/UpdateCheckerTest.php
+++ b/tests/UpdateCheckerTest.php
@@ -5,13 +5,9 @@ namespace BringYourOwnIdeas\UpdateChecker\Tests;
 use BringYourOwnIdeas\Maintenance\Util\ComposerLoader;
 use BringYourOwnIdeas\UpdateChecker\UpdateChecker;
 use Composer\Composer;
-use PHPUnit_Framework_TestCase;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 
-/**
- * @mixin PHPUnit_Framework_TestCase
- */
 class UpdateCheckerTest extends SapphireTest
 {
     protected $usesDatabase = true;
@@ -26,7 +22,7 @@ class UpdateCheckerTest extends SapphireTest
         parent::setUp();
 
         // Mock composer and composer loader
-        $composer = $this->getMockBuilder(Composer::Class)->getMock();
+        $composer = $this->getMockBuilder(Composer::class)->getMock();
         $composerLoader = $this->getMockBuilder(ComposerLoader::class)
             ->disableOriginalConstructor()
             ->setMethods(['getComposer'])
@@ -44,17 +40,13 @@ class UpdateCheckerTest extends SapphireTest
     {
         $mockPackage = new \Composer\Package\Package('foo/bar', '2.3.4.0', '2.3.4');
         $mockPackage->setSourceReference('foobar123');
-
-        // No available update
-        $this->updateChecker->expects($this->at(0))
+        $this->updateChecker
+            ->expects($this->exactly(2))
             ->method('findLatestPackage')
-            ->will($this->returnValue(false));
-
-        // There is latest version though
-        $this->updateChecker->expects($this->at(1))
-            ->method('findLatestPackage')
-            ->will($this->returnValue($mockPackage));
-
+            ->willReturnOnConsecutiveCalls(
+                false,
+                $mockPackage,
+            );
         $result = $this->updateChecker->checkForUpdates($mockPackage, '~1.2.0');
         $this->assertArrayNotHasKey('AvailableVersion', $result, 'No available update is recorded');
         $this->assertArrayNotHasKey('AvailableHash', $result, 'No available update is recorded');


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10294

https://github.com/emteknetnz/recipe-kitchen-sink/runs/6185849712?check_suite_focus=true#step:10:58

Fixes this warning
```
1) BringYourOwnIdeas\UpdateChecker\Tests\UpdateCheckerTest::testCheckForUpdates
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.
```